### PR TITLE
fix: import in CsvOrder.ts

### DIFF
--- a/src/models/CsvOrder.ts
+++ b/src/models/CsvOrder.ts
@@ -4,7 +4,7 @@ import { Format } from "../enums/Format";
 import { Address } from "./Address";
 import { Template } from "./Template";
 import { ICsvOrder } from "./_interfaces/ICsvOrder";
-import { CsvStatus, FriendlyCsvStatusText } from "src/enums/CsvStatus";
+import { CsvStatus, FriendlyCsvStatusText } from "../enums/CsvStatus";
 import { Order } from "./Order";
 import { PaginatedResponse } from "./PaginatedResponse";
 


### PR DESCRIPTION
**Problem**:
After installing the package with npm, building the project leads to the following error:
```
node_modules/@print-one/print-one-js/lib/models/CsvOrder.d.ts:7:50 - error TS2307: Cannot find module 'src/enums/CsvStatus' or its corresponding type declarations.

7 import { CsvStatus, FriendlyCsvStatusText } from "src/enums/CsvStatus";
```
Upon closer inspection, it seems to be due to a problem with the import defined in the CsvOrder.ts file.

**Solution**:
Changed CsvOrder.ts to have only relative paths as its import, and not the absolute path.

**Testing**:
Ran npm build successfully after the change, ran tests.