### PR TITLE
feat: add isLive search query to create batch

### DIFF
--- a/src/PrintOne.ts
+++ b/src/PrintOne.ts
@@ -60,7 +60,10 @@ export type RequestHandler = new (
   options: Required<PrintOneOptions>,
   debug: PrintOneDebugger,
 ) => HttpHandler<
-  { headers: Record<string, string>; params: Record<string, string> },
+  {
+    headers: Record<string, string>;
+    params: Record<string, string | number | boolean>;
+  },
   unknown
 >;
 

--- a/src/PrintOne.ts
+++ b/src/PrintOne.ts
@@ -497,13 +497,14 @@ export class PrintOne extends UnsafeCreationContext {
   public async createOrder(data: CreateOrder): Promise<Order> {
     const template = data.templateId ?? data.template;
     const templateId = template instanceof Template ? template.id : template;
+    const searchParams = `?isLive=${String(data.isLive ?? false)}`;
 
     const sendDateStr =
       data.sendDate instanceof Date
         ? data.sendDate.toISOString()
         : data.sendDate;
 
-    const response = await this.v2Client.POST<IOrder>("orders", {
+    const response = await this.v2Client.POST<IOrder>("orders" + searchParams, {
       sender: data.sender,
       recipient: data.recipient,
       templateId: templateId,

--- a/src/PrintOne.ts
+++ b/src/PrintOne.ts
@@ -661,15 +661,19 @@ export class PrintOne extends UnsafeCreationContext {
       data.ready instanceof Date ? data.ready.toISOString() : data.ready;
     const templateId =
       typeof data.template === "string" ? data.template : data.template.id;
+    const searchParams = `?isLive=${String(data.isLive ?? false)}`;
 
-    const response = await this.v2Client.POST<IBatch>("batches", {
-      name: data.name,
-      billingId: data.billingId,
-      templateId: templateId,
-      finish: data.finish,
-      ready: ready ? ready : null,
-      sender: data.sender,
-    });
+    const response = await this.v2Client.POST<IBatch>(
+      "batches" + searchParams,
+      {
+        name: data.name,
+        billingId: data.billingId,
+        templateId: templateId,
+        finish: data.finish,
+        ready: ready ? ready : null,
+        sender: data.sender,
+      },
+    );
 
     return new Batch(this.protected, response);
   }

--- a/src/PrintOne.ts
+++ b/src/PrintOne.ts
@@ -59,7 +59,11 @@ export type RequestHandler = new (
   token: string,
   options: Required<PrintOneOptions>,
   debug: PrintOneDebugger,
-) => HttpHandler<{ headers: Record<string, string> }, unknown>;
+) => HttpHandler<
+  { headers: Record<string, string>; params: Record<string, string> },
+  unknown
+>;
+
 export type PrintOneOptions = Partial<{
   url: string;
   /**
@@ -497,24 +501,26 @@ export class PrintOne extends UnsafeCreationContext {
   public async createOrder(data: CreateOrder): Promise<Order> {
     const template = data.templateId ?? data.template;
     const templateId = template instanceof Template ? template.id : template;
-    const searchParams = `?isLive=${String(data.isLive ?? false)}`;
-
     const sendDateStr =
       data.sendDate instanceof Date
         ? data.sendDate.toISOString()
         : data.sendDate;
 
-    const response = await this.v2Client.POST<IOrder>("orders" + searchParams, {
-      sender: data.sender,
-      recipient: data.recipient,
-      templateId: templateId,
-      finish: data.finish,
-      mergeVariables: data.mergeVariables,
-      billingId: data.billingId,
-      sendDate: sendDateStr,
-      sendDateOffset: data.sendDateOffset,
-      metadata: data.metadata,
-    });
+    const response = await this.v2Client.POST<IOrder>(
+      "orders",
+      {
+        sender: data.sender,
+        recipient: data.recipient,
+        templateId: templateId,
+        finish: data.finish,
+        mergeVariables: data.mergeVariables,
+        billingId: data.billingId,
+        sendDate: sendDateStr,
+        sendDateOffset: data.sendDateOffset,
+        metadata: data.metadata,
+      },
+      { params: { isLive: data.isLive ?? false } },
+    );
 
     return new Order(this.protected, response);
   }
@@ -662,10 +668,9 @@ export class PrintOne extends UnsafeCreationContext {
       data.ready instanceof Date ? data.ready.toISOString() : data.ready;
     const templateId =
       typeof data.template === "string" ? data.template : data.template.id;
-    const searchParams = `?isLive=${String(data.isLive ?? false)}`;
 
     const response = await this.v2Client.POST<IBatch>(
-      "batches" + searchParams,
+      "batches",
       {
         name: data.name,
         billingId: data.billingId,
@@ -673,6 +678,9 @@ export class PrintOne extends UnsafeCreationContext {
         finish: data.finish,
         ready: ready ? ready : null,
         sender: data.sender,
+      },
+      {
+        params: { isLive: data.isLive ?? false },
       },
     );
 

--- a/src/models/Batch.ts
+++ b/src/models/Batch.ts
@@ -28,7 +28,6 @@ export type CreateBatchOrder = {
   mergeVariables?: Record<string, string>;
   autoGenNextBatch?: boolean;
   metadata?: Record<string, string | undefined>;
-  isLive?: boolean;
 };
 
 export class Batch extends Model<IBatch> {

--- a/src/models/Batch.ts
+++ b/src/models/Batch.ts
@@ -79,6 +79,10 @@ export class Batch extends Model<IBatch> {
     return this._data.estimatedTax;
   }
 
+  public get requiredCount(): number {
+    return this._data.requiredCount;
+  }
+
   public get sender(): Address {
     return this._data.sender;
   }

--- a/src/models/Batch.ts
+++ b/src/models/Batch.ts
@@ -19,6 +19,7 @@ export type CreateBatch = {
   template: string | Template;
   finish: Finish;
   ready?: Date | boolean;
+  isLive?: boolean;
   sender?: Address;
 };
 

--- a/src/models/Batch.ts
+++ b/src/models/Batch.ts
@@ -28,6 +28,7 @@ export type CreateBatchOrder = {
   mergeVariables?: Record<string, string>;
   autoGenNextBatch?: boolean;
   metadata?: Record<string, string | undefined>;
+  isLive?: boolean;
 };
 
 export class Batch extends Model<IBatch> {
@@ -152,8 +153,10 @@ export class Batch extends Model<IBatch> {
    * Create a new order in the batch
    */
   public async createOrder(order: CreateBatchOrder): Promise<Order> {
+    const searchParams = `?isLive=${String(this.isBillable)}`;
+
     const data = await this._protected.clientV2.POST<IOrder>(
-      `/batches/${this.id}/orders`,
+      `/batches/${this.id}/orders` + searchParams,
       {
         recipient: order.recipient,
         mergeVariables: order.mergeVariables,

--- a/src/models/Batch.ts
+++ b/src/models/Batch.ts
@@ -19,6 +19,7 @@ export type CreateBatch = {
   template: string | Template;
   finish: Finish;
   ready?: Date | boolean;
+  /** @default false */
   isLive?: boolean;
   sender?: Address;
 };
@@ -152,16 +153,15 @@ export class Batch extends Model<IBatch> {
    * Create a new order in the batch
    */
   public async createOrder(order: CreateBatchOrder): Promise<Order> {
-    const searchParams = `?isLive=${String(this.isBillable)}`;
-
     const data = await this._protected.clientV2.POST<IOrder>(
-      `/batches/${this.id}/orders` + searchParams,
+      `/batches/${this.id}/orders`,
       {
         recipient: order.recipient,
         mergeVariables: order.mergeVariables,
         autoGenNextBatch: order.autoGenNextBatch,
         metadata: order.metadata,
       },
+      { params: { isLive: this.isBillable } },
     );
 
     return new Order(this._protected, data);

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -19,6 +19,7 @@ export type CreateOrder = {
   sendDate?: Date | string;
   sendDateOffset?: number;
   metadata?: Record<string, string | undefined>;
+  isLive?: boolean;
 } & (
   | {
       template: Template | string;

--- a/src/models/_interfaces/IBatch.ts
+++ b/src/models/_interfaces/IBatch.ts
@@ -11,6 +11,7 @@ export type IBatch = {
   templateId: string;
   estimatedPrice: number;
   estimatedTax: number;
+  requiredCount: number;
   sender: Address;
   sendDate: string | null;
   status: string;

--- a/test/Batch.spec.ts
+++ b/test/Batch.spec.ts
@@ -60,26 +60,6 @@ async function addOrders(count: number): Promise<void> {
   );
 }
 
-describe("createLiveBatch", function () {
-  it("should create a live batch", async function () {
-    // arrange
-
-    // act
-    const batch = await client.createBatch({
-      template: template,
-      name: `Test Batch ${new Date().toISOString().replaceAll(":", "-")}`,
-      finish: Finish.GLOSSY,
-      sender: address,
-      isLive: true,
-    });
-
-    // assert
-    expect(batch).toBeDefined();
-    expect(batch).toBeInstanceOf(Batch);
-    expect(batch.isBillable).toBeTrue();
-  });
-});
-
 describe("createOrder", function () {
   it("should create an order to the batch", async function () {
     // arrange

--- a/test/Batch.spec.ts
+++ b/test/Batch.spec.ts
@@ -35,14 +35,14 @@ beforeAll(async function () {
   });
 });
 
-// beforeEach(async function () {
-//   batch = await client.createBatch({
-//     template: template,
-//     name: `Test Batch ${new Date().toISOString().replaceAll(":", "-")}`,
-//     finish: Finish.GLOSSY,
-//     sender: address,
-//   });
-// });
+beforeEach(async function () {
+  batch = await client.createBatch({
+    template: template,
+    name: `Test Batch ${new Date().toISOString().replaceAll(":", "-")}`,
+    finish: Finish.GLOSSY,
+    sender: address,
+  });
+});
 
 async function addOrders(count: number): Promise<void> {
   await Promise.all(

--- a/test/Batch.spec.ts
+++ b/test/Batch.spec.ts
@@ -35,14 +35,14 @@ beforeAll(async function () {
   });
 });
 
-beforeEach(async function () {
-  batch = await client.createBatch({
-    template: template,
-    name: `Test Batch ${new Date().toISOString().replaceAll(":", "-")}`,
-    finish: Finish.GLOSSY,
-    sender: address,
-  });
-});
+// beforeEach(async function () {
+//   batch = await client.createBatch({
+//     template: template,
+//     name: `Test Batch ${new Date().toISOString().replaceAll(":", "-")}`,
+//     finish: Finish.GLOSSY,
+//     sender: address,
+//   });
+// });
 
 async function addOrders(count: number): Promise<void> {
   await Promise.all(
@@ -59,6 +59,26 @@ async function addOrders(count: number): Promise<void> {
     ),
   );
 }
+
+describe("createLiveBatch", function () {
+  it("should create a live batch", async function () {
+    // arrange
+
+    // act
+    const batch = await client.createBatch({
+      template: template,
+      name: `Test Batch ${new Date().toISOString().replaceAll(":", "-")}`,
+      finish: Finish.GLOSSY,
+      sender: address,
+      isLive: true,
+    });
+
+    // assert
+    expect(batch).toBeDefined();
+    expect(batch).toBeInstanceOf(Batch);
+    expect(batch.isBillable).toBeTrue();
+  });
+});
 
 describe("createOrder", function () {
   it("should create an order to the batch", async function () {

--- a/test/PrintOne.spec.ts
+++ b/test/PrintOne.spec.ts
@@ -1764,7 +1764,10 @@ describe("createBatch", function () {
     expect(batch.format).toEqual(Format.POSTCARD_SQ15);
     expect(batch.templateId).toEqual(template.id);
     expect(batch.isBillable).toEqual(expect.any(Boolean));
-    expect(batch.estimatedPrice).toEqual(0);
+    expect(batch.requiredCount).toEqual(expect.any(Number));
+    expect(batch.estimatedPrice).toEqual(
+      expect.toBeOneOf([undefined, expect.any(Number)]),
+    );
     expect(batch.sendDate).toEqual(
       expect.toBeOneOf([undefined, expect.any(Date)]),
     );


### PR DESCRIPTION
When not using an API key (OAuth), it was not possible to create a live batch.

Adding the `isLive` search query allows for this.

<img width="247" height="41" alt="image" src="https://github.com/user-attachments/assets/0c722c08-c6c1-4ccd-9093-57455261d112" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added optional `isLive` support when creating orders and batches, allowing control of live mode status for newly created items.
  * When not provided, `isLive` defaults to `false`.
  * Live mode is now sent via the request query parameters while keeping existing request body behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->